### PR TITLE
Bump actions/cache to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 20.x
           registry-url: https://registry.npmjs.org
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ~/.npm
           key: v1-${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
### Description
As stated on the article linked below, starting February 1st, 2025, Actions’ cache storage will move to a new architecture and as result @actions/cache and @actions/toolkit v1 and v2 (and other specific versions as well) will stop working making all workflows that use them obsolete and unable to run. Therefore it is recommended to update the versions to v4.

Link with more information regarding this issue:
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/