### PR TITLE
Update TS to 6.0.3

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.LICHTBLICK_GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: '24'
 
       - run: corepack enable
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,3 @@ jobs:
 
       - run: yarn install --immutable
       - run: yarn run lint
-
-      # publish version tags
-      - name: npm publish
-        run: npm publish --access public
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Configure Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+
+      - run: corepack enable
+
+      - run: npm ci
+      - run: npm publish --access public --provenance

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,4 @@ jobs:
 
       - run: corepack enable
 
-      - run: npm ci
       - run: npm publish --access public --provenance

--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ To use, run `npm i --save-dev @lichtblick/tsconfig`, then extend your `tsconfig.
 }
 ```
 
+## Releasing
+
+Two GitHub Actions workflows are involved:
+
+- **Auto Bump Version** (`.github/workflows/bump-version.yml`) runs on every push
+  to `main`. It bumps the `patch` version in `package.json` and commits the change
+  back to `main`. So merging a PR keeps the version moving automatically — but it
+  does **not** publish to npm.
+- **Publish to NPM** (`.github/workflows/release.yml`) runs only when a GitHub
+  **Release** is published. That event is what triggers `npm publish`.
+
+### To publish a release
+
+```sh
+# 1. update local main (includes the auto-bumped version)
+git checkout main && git pull
+
+# 2. read the current version to tag against
+tag="v$(node -p "require('./package.json').version")" && echo "$tag"
+
+# 3. create + publish a GitHub Release for that version
+git tag "$tag" && git push origin "$tag"
+gh release create "$tag" --generate-notes
+```
+
+Publishing the Release (step 3, via `gh` or the GitHub UI) emits the
+`release: published` event that runs the publish workflow.
+
+> **Note:** the auto-bump only ever does a `patch` bump. For a breaking change,
+> manually bump the `major` (or `minor`) in `package.json` before releasing so the
+> published version reflects semver.
+
 ## License
 
 [MIT License](/LICENSE.md)

--- a/README.md
+++ b/README.md
@@ -20,10 +20,3 @@ To use, run `npm i --save-dev @lichtblick/tsconfig`, then extend your `tsconfig.
 ## License
 
 [MIT License](/LICENSE.md)
-
-## Releasing
-
-```sh
-tag=$(npm version minor) && echo "$tag"
-git push && git push origin "$tag"
-```

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Publishing the Release (step 3, via `gh` or the GitHub UI) emits the
 
 > **Note:** the auto-bump only ever does a `patch` bump. For a breaking change,
 > manually bump the `major` (or `minor`) in `package.json` before releasing so the
-> published version reflects semver.
+> published version reflects that correctly.
 
 ## License
 

--- a/base.json
+++ b/base.json
@@ -7,7 +7,10 @@
     "module": "es2022",
     "target": "es2022",
     "lib": ["es2022"],
-    "moduleResolution": "node",
+
+    // "node"/"node10" resolution is deprecated as of TS 6.0; use "bundler" which
+    // matches the esbuild/babel transpiler workflows this config targets
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "importHelpers": true,
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-prettier": "5.1.3",
     "jest": "29.5.0",
     "prettier": "3.3.2",
-    "typescript": "5.6.3"
+    "typescript": "6.0.3"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lichtblick/tsconfig",
   "private": false,
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Base TypeScript configuration for Lichtblick projects",
   "license": "MIT",
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4448,7 +4448,12 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@5.6.3, "typescript@^4 || ^5":
+typescript@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
+
+"typescript@^4 || ^5":
   version "5.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==


### PR DESCRIPTION
## Summary

Bump TypeScript to `6.0.3` and update the base config for TS 6.0 compatibility.

## Changes

- **`typescript` → `6.0.3`** (`package.json` devDependency).
- **`moduleResolution: "node"` → `"bundler"`** (`base.json`).
  TS 6.0 renamed `node` to `node10` and now errors that it's deprecated
  (`TS5107`), with removal planned for TS 7.0. `bundler` is the modern
  replacement and matches the esbuild/babel transpiler workflows this config
  already targets (`isolatedModules`, `module: es2022`). Keeps extensionless
  relative imports working, so it's non-breaking for current consumers.
- Update release process


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript to a newer version.
  * Switched module resolution to a more modern bundler-compatible setting, which may improve compatibility with current build workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->